### PR TITLE
Test on Python 3.7 instead of Python 3.7 Early Development Version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,13 +89,21 @@ matrix:
           env: GROUP=python
         - python: 3.5
           env: GROUP=dataflow
-        - python: "3.7-dev"
+        - python: 3.7
+          dist: xenial
+          sudo: true
           env: GROUP=python
-        - python: "3.7-dev"
+        - python: 3.7
+          dist: xenial
+          sudo: true
           env: GROUP=js/base
-        - python: "3.7-dev"
+        - python: 3.7
+          dist: xenial
+          sudo: true
           env: GROUP=js/services
-        - python: "3.7-dev"
+        - python: 3.7
+          dist: xenial
+          sudo: true
           env: GROUP=js/dataflow
 
 after_success:


### PR DESCRIPTION
https://github.com/travis-ci/travis-ci/issues/9815

Please see the above Travis issue, this is a pull to test our compatibility with Python 3.7 since we currently test on the early development version of Py 3.7 which was a Beta and lacks many of the features that the released version of Py 3.7 has along with the stability that the final product has as well.